### PR TITLE
Refactor LCD and buzzer code into separate modules

### DIFF
--- a/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Inc/buzzer.h
+++ b/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Inc/buzzer.h
@@ -1,0 +1,9 @@
+#ifndef BUZZER_H
+#define BUZZER_H
+
+#include "main.h"
+#include <stdint.h>
+
+void Buzzer_PlayFreq(uint16_t freq, uint16_t duration_ms);
+
+#endif // BUZZER_H

--- a/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Inc/lcd.h
+++ b/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Inc/lcd.h
@@ -1,0 +1,11 @@
+#ifndef LCD_H
+#define LCD_H
+
+#include "main.h"
+#include <stdint.h>
+
+void LCD_Init(void);
+void LCD_WriteCmd(uint8_t cmd);
+void LCD_WriteData(uint8_t data);
+
+#endif // LCD_H

--- a/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/buzzer.c
+++ b/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/buzzer.c
@@ -1,0 +1,20 @@
+#include "buzzer.h"
+
+extern TIM_HandleTypeDef htim1;
+
+static void Buzzer_SetDuty(uint16_t duty)
+{
+    __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, duty);
+}
+
+void Buzzer_PlayFreq(uint16_t freq, uint16_t duration_ms)
+{
+    uint32_t timer_clk = 1000000;  // TIM1 clock after prescaler = 64 MHz / (63 + 1)
+    uint32_t period = timer_clk / freq;
+
+    __HAL_TIM_SET_AUTORELOAD(&htim1, period - 1);
+    __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, period / 2);  // 50% duty
+    HAL_Delay(duration_ms);
+    Buzzer_SetDuty(0);
+}
+

--- a/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/lcd.c
+++ b/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/lcd.c
@@ -1,0 +1,124 @@
+#include "lcd.h"
+#include <stdio.h>
+
+extern SPI_HandleTypeDef hspi1;
+
+#define CS_Pin        LCD_CS_Pin
+#define CS_GPIO_Port  LCD_CS_GPIO_Port
+#define RST_Pin       LCD_RESET_Pin
+#define RST_GPIO_Port LCD_RESET_GPIO_Port
+
+#define LCD_START_CMD   0xF8
+#define LCD_START_DATA  0xFA
+
+/* reverse a 4-bit value: b3 b2 b1 b0 -> b0 b1 b2 b3 */
+static uint8_t rev4(uint8_t n)
+{
+    n = ((n & 0x3) << 2) | ((n & 0xC) >> 2); // swap bit-pairs
+    n = ((n & 0x5) << 1) | ((n & 0xA) >> 1); // swap neighbours
+    return n & 0x0F;
+}
+
+static void LCD_Write(uint8_t startByte, uint8_t val)
+{
+    uint8_t tx[3] = {
+        startByte,
+        (uint8_t)(rev4(val & 0x0F) << 4),          // D0..D3 → bits 7-4
+        (uint8_t)(rev4(val >> 4)    << 4)           // D4..D7 → bits 7-4
+    };
+
+    HAL_GPIO_WritePin(CS_GPIO_Port, CS_Pin, GPIO_PIN_RESET);
+    HAL_SPI_Transmit(&hspi1, tx, 3, HAL_MAX_DELAY);
+    HAL_GPIO_WritePin(CS_GPIO_Port, CS_Pin, GPIO_PIN_SET);
+}
+
+static uint8_t LCD_ReadBF_AC(void)           /* returns BF|AC                */
+{
+    uint8_t tx[3] = { 0xFC, 0, 0 };          /* 111111 RW=1 RS=0 0           */
+    uint8_t rx[3];
+
+    HAL_GPIO_WritePin(CS_GPIO_Port, CS_Pin, GPIO_PIN_RESET);
+    HAL_SPI_TransmitReceive(&hspi1, tx, rx, 3, HAL_MAX_DELAY);
+    HAL_GPIO_WritePin(CS_GPIO_Port, CS_Pin, GPIO_PIN_SET);
+
+    return rx[1];                            /* bit7 = BF, bits6-0 = AC      */
+}
+
+/* wait until BF=0 – but give up after ~2 ms so we don't hang forever */
+static void LCD_WaitReady(void)
+{
+    const uint32_t t0 = HAL_GetTick();        /* current tick (1 ms resolution) */
+
+    for (;;) {
+        uint8_t bf_ac = LCD_ReadBF_AC();      /* bit7 = BF                     */
+        if ((bf_ac & 0x80) == 0)              /* BF cleared → ready            */
+            return;
+
+        if (HAL_GetTick() - t0 > 2) {        /* 2-ms guard-time              */
+            printf("BF never cleared (last = 0x%02X) – giving up\r\n", bf_ac);
+            return;                           /* or Error_Handler();           */
+        }
+    }
+}
+
+void LCD_WriteCmd(uint8_t cmd)
+{
+    //LCD_WaitReady();                         /* NEW                           */
+    LCD_Write(LCD_START_CMD, cmd);
+}
+
+void LCD_WriteData(uint8_t dat)
+{
+    //LCD_WaitReady();                         /* NEW                           */
+    LCD_Write(LCD_START_DATA, dat);
+}
+
+static void LCD_Reset(void)
+{
+    HAL_GPIO_WritePin(RST_GPIO_Port, RST_Pin, GPIO_PIN_RESET); /* RST low */
+    HAL_Delay(20);                                              /* ≥20 µs  */
+    HAL_GPIO_WritePin(RST_GPIO_Port, RST_Pin, GPIO_PIN_SET);   /* RST high */
+    HAL_Delay(100);                                             /* let VOUT settle */
+}
+
+void LCD_Init(void)
+{
+    HAL_Delay(200);
+    LCD_Reset();  // Ensure proper reset timing
+
+    LCD_WriteCmd(0x3A); HAL_Delay(1);  // Function set (RE=1)
+    LCD_WriteCmd(0x09); HAL_Delay(1);  // 4-line display
+    LCD_WriteCmd(0x06); HAL_Delay(1);  // Entry mode
+    LCD_WriteCmd(0x1E); HAL_Delay(1);  // Bias set BS1=1
+
+    LCD_WriteCmd(0x39); HAL_Delay(1);  // Function set (RE=0, IS=1)
+    LCD_WriteCmd(0x1B); HAL_Delay(1);  // Internal OSC
+    LCD_WriteCmd(0x6C); HAL_Delay(500); // Follower control
+
+    LCD_WriteCmd(0x54); HAL_Delay(1);  // Power control (Booster on, contrast C5/C4 = 1/0)
+    LCD_WriteCmd(0x79); HAL_Delay(1);  // Contrast set (C3–C0 = 0x0A)
+
+    LCD_WriteCmd(0x38); HAL_Delay(1);  // Function set (RE=0, IS=0)
+    LCD_WriteCmd(0x0F); HAL_Delay(1);  // Display ON, cursor OFF, blink OFF
+}
+
+/* Returns the second byte of the 24-bit frame.
+   bit7 = Busy-Flag, bits6-0 = Address Counter                    */
+static uint8_t LCD_ReadBusy(void)
+{
+        /* 16 clocks = 2 bytes: 1× start byte + 1× dummy */
+            uint8_t tx[2] = { 0xFC, 0x00 };          // 111111 RW=1 RS=0 0  + dummy
+            uint8_t rx[2] = { 0 };
+
+            HAL_GPIO_WritePin(CS_GPIO_Port, CS_Pin, GPIO_PIN_RESET);
+            HAL_SPI_TransmitReceive(&hspi1, tx, rx, 2, HAL_MAX_DELAY);
+            HAL_GPIO_WritePin(CS_GPIO_Port, CS_Pin, GPIO_PIN_SET);
+
+            return rx[1];                            // bit7 = BF, bits6-0 = AC
+}
+
+static void LCD_WriteChar(char c)
+{
+    LCD_WriteData((uint8_t)c);
+}
+

--- a/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/main.c
+++ b/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/main.c
@@ -25,6 +25,8 @@
 #include <string.h>
 #include <stddef.h>       // for size_t
 #include <stdint.h>
+#include "lcd.h"
+#include "buzzer.h"
 
 /* USER CODE END Includes */
 
@@ -35,21 +37,8 @@
 
 /* Private define ------------------------------------------------------------*/
 /* USER CODE BEGIN PD */
-#define CS_Pin        GPIO_PIN_0
-#define CS_GPIO_Port  GPIOB
-#define RST_Pin       GPIO_PIN_1
-#define RST_GPIO_Port GPIOB
-#define BTN_MINUS_Pin GPIO_PIN_6
-#define BTN_PLUS_Pin  GPIO_PIN_7
-#define BTN_MODE_Pin  GPIO_PIN_8
-#define BTN_MUTE_Pin  GPIO_PIN_9
-#define BTN_PORT      GPIOB
 #define VREFINT_CAL (*(uint16_t*)0x1FFF75AA)  // Factory-calibrated ADC value for VREFINT at 3.0 V
 #define VREFINT_MV 3000  // Calibration is done at 3.00 V
-
-/* SSD1803A serial “start-byte” – see Fig 7-11 in the datasheet :contentReference[oaicite:6]{index=6} */
-#define LCD_START_CMD   0xF8      /* 11111 - RW=0, RS=0, 0 */
-#define LCD_START_DATA  0xFA      /* 11111 - RW=0, RS=1, 0 */
 
 
 /* USER CODE END PD */
@@ -99,125 +88,11 @@ uint32_t  Read_Battery_mV(void);
 uint32_t Read_VDDA_mV(void);
 void Monitor_ADC_Drop_Spikes();
 
-static void LCD_Reset(void);
-static void LCD_Write(uint8_t startByte, uint8_t val);
-static void LCD_WriteCmd(uint8_t cmd);
-static void LCD_WriteData(uint8_t data);
-static void LCD_Init(void);
-
 /* USER CODE END PFP */
 
 /* Private user code ---------------------------------------------------------*/
 /* USER CODE BEGIN 0 */
 
-/* --- low-level helpers --------------------------------------------------- */
-/* reverse a 4-bit value: b3 b2 b1 b0 -> b0 b1 b2 b3 */
-static uint8_t rev4(uint8_t n)
-{
-    n = ((n & 0x3) << 2) | ((n & 0xC) >> 2); // swap bit-pairs
-    n = ((n & 0x5) << 1) | ((n & 0xA) >> 1); // swap neighbours
-    return n & 0x0F;
-}
-
-static void LCD_Write(uint8_t startByte, uint8_t val)
-{
-    uint8_t tx[3] = {
-        startByte,
-        (uint8_t)(rev4(val & 0x0F) << 4),          // D0..D3 → bits 7-4
-        (uint8_t)(rev4(val >> 4)    << 4)           // D4..D7 → bits 7-4
-    };
-
-    HAL_GPIO_WritePin(CS_GPIO_Port, CS_Pin, GPIO_PIN_RESET);
-    HAL_SPI_Transmit(&hspi1, tx, 3, HAL_MAX_DELAY);
-    HAL_GPIO_WritePin(CS_GPIO_Port, CS_Pin, GPIO_PIN_SET);
-}
-
-static uint8_t LCD_ReadBF_AC(void)           /* returns BF|AC                */
-{
-    uint8_t tx[3] = { 0xFC, 0, 0 };          /* 111111 RW=1 RS=0 0           */
-    uint8_t rx[3];
-
-    HAL_GPIO_WritePin(CS_GPIO_Port, CS_Pin, GPIO_PIN_RESET);
-    HAL_SPI_TransmitReceive(&hspi1, tx, rx, 3, HAL_MAX_DELAY);
-    HAL_GPIO_WritePin(CS_GPIO_Port, CS_Pin, GPIO_PIN_SET);
-
-    return rx[1];                            /* bit7 = BF, bits6-0 = AC      */
-}
-
-/* wait until BF=0 – but give up after ~2 ms so we don't hang forever */
-static void LCD_WaitReady(void)
-{
-    const uint32_t t0 = HAL_GetTick();        /* current tick (1 ms resolution) */
-
-    for (;;) {
-        uint8_t bf_ac = LCD_ReadBF_AC();      /* bit7 = BF                     */
-        if ((bf_ac & 0x80) == 0)              /* BF cleared → ready            */
-            return;
-
-        if (HAL_GetTick() - t0 > 2) {        /* 2-ms guard-time              */
-            printf("BF never cleared (last = 0x%02X) – giving up\r\n", bf_ac);
-            return;                           /* or Error_Handler();           */
-        }
-    }
-}
-
-static void LCD_WriteCmd(uint8_t cmd)
-{
-    //LCD_WaitReady();                         /* NEW                           */
-    LCD_Write(LCD_START_CMD, cmd);
-}
-
-static void LCD_WriteData(uint8_t dat)
-{
-    //LCD_WaitReady();                         /* NEW                           */
-    LCD_Write(LCD_START_DATA, dat);
-}
-
-static void LCD_Reset(void)
-{
-    HAL_GPIO_WritePin(RST_GPIO_Port, RST_Pin, GPIO_PIN_RESET); /* RST low */
-    HAL_Delay(20);                                              /* ≥20 µs  */
-    HAL_GPIO_WritePin(RST_GPIO_Port, RST_Pin, GPIO_PIN_SET);   /* RST high */
-    HAL_Delay(100);                                             /* let VOUT settle */
-}
-
-static void LCD_Init(void)
-{
-    HAL_Delay(200);
-    LCD_Reset();  // Ensure proper reset timing
-
-    LCD_WriteCmd(0x3A); HAL_Delay(1);  // Function set (RE=1)
-    LCD_WriteCmd(0x09); HAL_Delay(1);  // 4-line display
-    LCD_WriteCmd(0x06); HAL_Delay(1);  // Entry mode
-    LCD_WriteCmd(0x1E); HAL_Delay(1);  // Bias set BS1=1
-
-    LCD_WriteCmd(0x39); HAL_Delay(1);  // Function set (RE=0, IS=1)
-    LCD_WriteCmd(0x1B); HAL_Delay(1);  // Internal OSC
-    LCD_WriteCmd(0x6C); HAL_Delay(500); // Follower control
-
-    LCD_WriteCmd(0x54); HAL_Delay(1);  // Power control (Booster on, contrast C5/C4 = 1/0)
-    LCD_WriteCmd(0x79); HAL_Delay(1);  // Contrast set (C3–C0 = 0x0A)
-
-    LCD_WriteCmd(0x38); HAL_Delay(1);  // Function set (RE=0, IS=0)
-    LCD_WriteCmd(0x0F); HAL_Delay(1);  // Display ON, cursor OFF, blink OFF
-
-}
-
-
-/* Returns the second byte of the 24-bit frame.
-   bit7 = Busy-Flag, bits6-0 = Address Counter                    */
-static uint8_t LCD_ReadBusy(void)
-{
-	/* 16 clocks = 2 bytes: 1× start byte + 1× dummy */
-	    uint8_t tx[2] = { 0xFC, 0x00 };          // 111111 RW=1 RS=0 0  + dummy
-	    uint8_t rx[2] = { 0 };
-
-	    HAL_GPIO_WritePin(CS_GPIO_Port, CS_Pin, GPIO_PIN_RESET);
-	    HAL_SPI_TransmitReceive(&hspi1, tx, rx, 2, HAL_MAX_DELAY);
-	    HAL_GPIO_WritePin(CS_GPIO_Port, CS_Pin, GPIO_PIN_SET);
-
-	    return rx[1];                            // bit7 = BF, bits6-0 = AC
-}
 
 
 
@@ -235,25 +110,6 @@ static float MovingAvg_Add(float new_val)
 
 
 
-static void Buzzer_SetDuty(uint16_t duty)
-{
-    __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, duty);
-}
-void Buzzer_PlayFreq(uint16_t freq, uint16_t duration_ms)
-{
-    uint32_t timer_clk = 1000000;  // TIM1 clock after prescaler = 64 MHz / (63 + 1)
-    uint32_t period = timer_clk / freq;
-
-    __HAL_TIM_SET_AUTORELOAD(&htim1, period - 1);
-    __HAL_TIM_SET_COMPARE(&htim1, TIM_CHANNEL_1, period / 2);  // 50% duty
-    HAL_Delay(duration_ms);
-    Buzzer_SetDuty(0);
-}
-
-static void LCD_WriteChar(char c)
-{
-    LCD_WriteData((uint8_t)c);
-}
 
 /* USER CODE END 0 */
 


### PR DESCRIPTION
## Summary
- split LCD driver into `lcd.c/h`
- move buzzer control into `buzzer.c/h`
- update `main.c` to use new modules

## Testing
- `gcc -c firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/buzzer.c -I firmware/dripito-v1/InfusionBA/InfusionBA/Core/Inc -I firmware/dripito-v1/InfusionBA/InfusionBA/Drivers/STM32G0xx_HAL_Driver/Inc -I firmware/dripito-v1/InfusionBA/InfusionBA/Drivers/CMSIS/Device/ST/STM32G0xx/Include -I firmware/dripito-v1/InfusionBA/InfusionBA/Drivers/CMSIS/Include` *(fails: Please select first the target STM32G0xx device)*
- `gcc -c firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/lcd.c -I firmware/dripito-v1/InfusionBA/InfusionBA/Core/Inc -I firmware/dripito-v1/InfusionBA/InfusionBA/Drivers/STM32G0xx_HAL_Driver/Inc -I firmware/dripito-v1/InfusionBA/InfusionBA/Drivers/CMSIS/Device/ST/STM32G0xx/Include -I firmware/dripito-v1/InfusionBA/InfusionBA/Drivers/CMSIS/Include` *(fails: many unknown type name 'uint32_t' errors)*

------
https://chatgpt.com/codex/tasks/task_e_688f93a1cad483319d0d7e23b980efe7