### PR TITLE
Default target 100 mL/h and fast button hold adjustment

### DIFF
--- a/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/main.c
+++ b/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/main.c
@@ -72,7 +72,7 @@ volatile float    flow_window[FLOW_AVG_WINDOW] = {0};
 volatile uint8_t  flow_idx             = 0;          // circular buffer index
 volatile float    flow_avg_mlh         = 0.0f;       // moving average flow
 volatile float    total_volume_ml      = 0.0f;       // drops ÷ drip-factor
-volatile uint16_t target_rate_mlh = 50; // Example default: 50 mL/h
+volatile uint16_t target_rate_mlh = 100; // Default: 100 mL/h
 
 
 /* USER CODE END PV */


### PR DESCRIPTION
## Summary
- default infusion target set to 100 mL/h
- allow holding PLUS/MINUS buttons to rapidly change target

## Testing
- `gcc -std=c11 -Ifirmware/dripito-v1/InfusionBA/InfusionBA/Core/Inc -Ifirmware/dripito-v1/InfusionBA/InfusionBA/Drivers/STM32G0xx_HAL_Driver/Inc -Ifirmware/dripito-v1/InfusionBA/InfusionBA/Drivers/CMSIS/Include -Ifirmware/dripito-v1/InfusionBA/InfusionBA/Drivers/CMSIS/Device/ST/STM32G0xx/Include -DSTM32G030xx -c firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/ui.c 2>&1 | tail -n 20`
- `gcc -std=c11 -Ifirmware/dripito-v1/InfusionBA/InfusionBA/Core/Inc -Ifirmware/dripito-v1/InfusionBA/InfusionBA/Drivers/STM32G0xx_HAL_Driver/Inc -Ifirmware/dripito-v1/InfusionBA/InfusionBA/Drivers/CMSIS/Include -Ifirmware/dripito-v1/InfusionBA/InfusionBA/Drivers/CMSIS/Device/ST/STM32G0xx/Include -DSTM32G030xx -c firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/main.c 2>&1 | tail -n 20` (fails: `cmsis_gcc.h:209: Error: no such instruction: 'cpsid i'`)

------
https://chatgpt.com/codex/tasks/task_e_688fc558565c8331ac2493df1b420500