### PR TITLE
Implement flow deviation and drop stop alarms with mute

### DIFF
--- a/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Inc/alarm.h
+++ b/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Inc/alarm.h
@@ -1,0 +1,11 @@
+#ifndef ALARM_H
+#define ALARM_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "ui.h"
+
+void alarm_task(void);
+void alarm_mute(void);
+
+#endif /* ALARM_H */

--- a/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/alarm.c
+++ b/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/alarm.c
@@ -1,0 +1,79 @@
+#include "alarm.h"
+#include "buzzer.h"
+#include "main.h"
+
+extern volatile uint32_t last_drop_ms;
+extern volatile float    flow_mlh;
+extern volatile uint16_t target_rate_mlh;
+
+static enum alarm_id_e active_alarm = ALARM_NONE;
+static uint32_t         flow_dev_start_ms = 0;
+static uint32_t         last_beep_ms = 0;
+static bool             muted = false;
+
+static void alarm_trigger(enum alarm_id_e id)
+{
+    active_alarm = id;
+    muted = false;
+    ui_alarm_start(id);
+}
+
+void alarm_task(void)
+{
+    uint32_t now = HAL_GetTick();
+
+    /* handle active alarm */
+    if (active_alarm != ALARM_NONE) {
+        if (!muted && (now - last_beep_ms >= 500U)) {
+            last_beep_ms = now;
+            Buzzer_PlayFreq(4000, 50);
+        }
+
+        if (active_alarm == ALARM_STOP) {
+            if ((now - last_drop_ms) < 15000U) {
+                active_alarm = ALARM_NONE;
+                ui_alarm_clear();
+            }
+        } else if (active_alarm == ALARM_FLOW) {
+            float diff = flow_mlh > target_rate_mlh ?
+                          (flow_mlh - target_rate_mlh) :
+                          (target_rate_mlh - flow_mlh);
+            if (diff <= ((float)target_rate_mlh * 0.1f)) {
+                active_alarm = ALARM_NONE;
+                ui_alarm_clear();
+                flow_dev_start_ms = 0;
+            }
+        }
+        return;
+    }
+
+    /* stop alarm: no drop for 15 s */
+    if ((now - last_drop_ms) >= 15000U) {
+        alarm_trigger(ALARM_STOP);
+        return;
+    }
+
+    /* flow alarm: deviation >10% for 10 s */
+    if (target_rate_mlh > 0U) {
+        float diff = flow_mlh > target_rate_mlh ?
+                      (flow_mlh - target_rate_mlh) :
+                      (target_rate_mlh - flow_mlh);
+        if (diff > ((float)target_rate_mlh * 0.1f)) {
+            if (flow_dev_start_ms == 0U) {
+                flow_dev_start_ms = now;
+            } else if ((now - flow_dev_start_ms) >= 10000U) {
+                alarm_trigger(ALARM_FLOW);
+            }
+        } else {
+            flow_dev_start_ms = 0U;
+        }
+    } else {
+        flow_dev_start_ms = 0U;
+    }
+}
+
+void alarm_mute(void)
+{
+    muted = true;
+    buzzer_mute();
+}

--- a/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/main.c
+++ b/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/main.c
@@ -28,6 +28,7 @@
 #include "lcd.h"
 #include "buzzer.h"
 #include "ui.h"
+#include "alarm.h"
 
 /* USER CODE END Includes */
 
@@ -96,6 +97,7 @@ void LCD_ShowBatteryPercentage(uint8_t percent);
 void Monitor_ADC_Drop_Spikes();
 void HandleSimulatedDrop(void);
 void HandleTargetAdjustment(void);
+void HandleMuteButton(void);
 
 /* USER CODE END PFP */
 
@@ -189,7 +191,9 @@ int main(void)
   {
           HandleTargetAdjustment();
           HandleSimulatedDrop();
+          HandleMuteButton();
           ui_task();
+          alarm_task();
 
           uint32_t batt_mv = Read_Battery_mV();
           uint8_t  batt_pct = Battery_mV_to_percent(batt_mv);
@@ -796,6 +800,20 @@ void HandleSimulatedDrop(void)
     }
 
     lastBtnMode = nowMode;
+}
+
+/* ---------- MUTE-button handler --------------------------------------- */
+void HandleMuteButton(void)
+{
+    static uint8_t lastMute = GPIO_PIN_SET;
+    uint8_t nowMute = HAL_GPIO_ReadPin(BTN_MUTE_GPIO_Port, BTN_MUTE_Pin);
+
+    if (nowMute == GPIO_PIN_RESET && lastMute == GPIO_PIN_SET) {
+        ui_on_button(BTN_MUTE, false);
+        HAL_Delay(200);
+    }
+
+    lastMute = nowMute;
 }
 
 

--- a/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/ui.c
+++ b/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/ui.c
@@ -18,6 +18,7 @@
 #include "ui.h"
 #include "lcd.h"      /* thin wrapper around LCD_Write*() from main.c */
 #include "buzzer.h"   /* start/stop helpers – see ui_alarm_start() */
+#include "alarm.h"    /* for alarm_mute() */
 
 /*---------------------------------------------------------------------------
  *  Compile‑time constants
@@ -251,7 +252,7 @@ void ui_on_button(enum ui_button_e btn, bool long_press)
             edit_rate = target_rate_mlh ? target_rate_mlh : 1;
             lcd_clear_shadow();
         } else if (btn == BTN_MUTE) {
-            buzzer_mute();             /* spec: silence non‑latched alarm */
+            alarm_mute();             /* silence active alarm */
         }
         break;
     /*-------------------------------------------------- SET -------------*/
@@ -272,7 +273,7 @@ void ui_on_button(enum ui_button_e btn, bool long_press)
     /*------------------------------------------------- ALARM ------------*/
     case UI_ALARM:
         if (btn == BTN_MUTE) {
-            buzzer_mute();                     /* silence buzzer only */
+            alarm_mute();                     /* silence buzzer only */
         }
         /* other buttons ignored */
         break;
@@ -286,6 +287,7 @@ void ui_alarm_start(enum alarm_id_e id)
 {
     current_alarm = id;
     ui_state = UI_ALARM;
+    LCD_Clear();
     lcd_clear_shadow();
 }
 


### PR DESCRIPTION
## Summary
- add alarm module monitoring flow deviation and drop absence
- wire mute button to silence alarms and clear LCD before alarm screen
- call alarm task from main loop

## Testing
- `cd firmware/dripito-v1/InfusionBA/InfusionBA && make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_688fd0c7f08883319482c8a199564838