### PR TITLE
Replace battery percentage with pseudo icon

### DIFF
--- a/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/ui.c
+++ b/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/ui.c
@@ -85,21 +85,29 @@ static void lcd_clear_shadow(void)
     for (int i=0;i<4;i++) memset(lcd_shadow[i], 0, sizeof(lcd_shadow[i]));
 }
 
+static void battery_icon(char *dst, uint8_t pct)
+{
+    dst[0] = '[';
+    for (int i = 0; i < 4; i++)
+        dst[i+1] = (pct >= (i+1)*25) ? '#' : ' ';
+    dst[5] = ']';
+    dst[6] = '\0';
+}
+
 /*---------------------------------------------------------------------------
  *  RUN screen rendering
  *---------------------------------------------------------------------------*/
 static void ui_render_run(void)
 {
-    /* L0: Flow ### mL/h 99%   (battery right aligned) */
-    char l0[LCD_CHARS+1]="Flow ";
+    /* L0: Flow ### mL/h */
+    char l0[LCD_CHARS+1] = "Flow ";
     print_rjust(l0+5, 3, (int)flow_mlh, NULL);
-    strcat(l0, " mL/h ");
+    strcat(l0, " mL/h");
+    int len0 = strlen(l0);
+    while (len0 < LCD_CHARS) l0[len0++] = ' ';
+    l0[len0] = '\0';
+
     uint8_t batt = Battery_mV_to_percent(Read_Battery_mV());
-    char batt_buf[5];
-    //sprintf(batt_buf, "%3u%%", batt);
-    int pad = LCD_CHARS - strlen(l0) - strlen(batt_buf);
-    while(pad-->0) strcat(l0, " ");
-    strcat(l0, batt_buf);
 
     /* L1: Target### mL/h or blanks */
     char l1[LCD_CHARS+1]="Target";
@@ -120,7 +128,14 @@ static void ui_render_run(void)
         sprintf(l2, "Infused%5.1f mL", total_volume_ml);
     }
 
-    lcd_line(0,l0); lcd_line(1,l1); lcd_line(2,l2); lcd_line(3,"                ");
+    char l3[LCD_CHARS+1];
+    memset(l3, ' ', LCD_CHARS);
+    l3[LCD_CHARS] = '\0';
+    char batt_buf[7];
+    battery_icon(batt_buf, batt);
+    strcpy(l3 + LCD_CHARS - strlen(batt_buf), batt_buf);
+
+    lcd_line(0,l0); lcd_line(1,l1); lcd_line(2,l2); lcd_line(3,l3);
 }
 
 /*---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove numeric battery display from top of run screen
- draw simple 4-bar battery icon at bottom-right instead

## Testing
- `make` *(fails: makefile:63: *** multiple target patterns. Stop.)*

------
https://chatgpt.com/codex/tasks/task_e_6890fdb91a0c8331b0faa5b3919a6c0b