### PR TITLE
Move battery percent to bottom-right

### DIFF
--- a/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Inc/lcd.h
+++ b/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Inc/lcd.h
@@ -14,7 +14,6 @@ void LCD_Init(void);                         /* power‑on sequence + clear    *
 void LCD_Clear(void);                        /* clear display, home cursor   */
 void LCD_SetCursor(uint8_t line);            /* 0‑based line select (0‑3)    */
 void LCD_Print(uint8_t line, const char *s); /* writes up to 16 chars        */
-void LCD_ShowBatteryPercentage(uint8_t pct); /* draws right‑aligned “99%”    */
 
 /*----------------------------------------------------------------------
  *  Low-level primitives (used internally or by LCD driver)

--- a/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/lcd.c
+++ b/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/lcd.c
@@ -1,5 +1,5 @@
 #include "lcd.h"
-#include <stdio.h>
+#include <string.h>
 
 extern SPI_HandleTypeDef hspi1;
 
@@ -34,19 +34,6 @@ void LCD_SplashScreen(void)
     LCD_Print(1, "   DRIPITO v1");
     //LCD_Print(2, "Leandro Catarci");
     //LCD_Print(3, "   GHE - ETHZ ");
-}
-
-void LCD_ShowBatteryPercentage(uint8_t percent)
-{
-    char buf[6];  // Enough for "100%"
-    snprintf(buf, sizeof(buf), "%3u%%", percent);
-
-    // Set cursor to top-right corner
-    // Line 0, column 16 – 4 chars from the end (0-based index)
-    LCD_WriteCmd(0x80 | (16 - strlen(buf)));  // Line 0 starts at 0x00
-
-    for (size_t i = 0; i < strlen(buf); ++i)
-        LCD_WriteData(buf[i]);
 }
 
 static void LCD_Write(uint8_t startByte, uint8_t val)

--- a/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/main.c
+++ b/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/main.c
@@ -92,7 +92,6 @@ static void MX_SPI1_Init(void);
 uint32_t  Read_Battery_mV(void);
 uint32_t Read_VDDA_mV(void);
 uint8_t Battery_mV_to_percent(uint32_t mv);
-void LCD_ShowBatteryPercentage(uint8_t percent);
 
 void Monitor_ADC_Drop_Spikes();
 void HandleModeButton(void);
@@ -196,9 +195,6 @@ int main(void)
           ui_task();
           alarm_task();
           Monitor_ADC_Drop_Spikes();
-          uint32_t batt_mv = Read_Battery_mV();
-          uint8_t  batt_pct = Battery_mV_to_percent(batt_mv);
-          LCD_ShowBatteryPercentage(batt_pct);
 
     /* USER CODE END WHILE */
 
@@ -652,10 +648,6 @@ void Monitor_ADC_Drop_Spikes(void)
         drop_count++;
 
         total_volume_ml = (float)drop_count / DRIP_FACTOR_GTT_PER_ML;
-
-        /* Battery */
-        uint32_t batt_mv  = Read_Battery_mV();
-        uint8_t  batt_pct = Battery_mV_to_percent(batt_mv);
 
         /* Time since power-up */
         uint32_t elapsed_ms = now;                       // HAL_GetTick base = boot

--- a/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/ui.c
+++ b/firmware/dripito-v1/InfusionBA/InfusionBA/Core/Src/ui.c
@@ -85,18 +85,6 @@ static void lcd_clear_shadow(void)
     for (int i=0;i<4;i++) memset(lcd_shadow[i], 0, sizeof(lcd_shadow[i]));
 }
 
-static void battery_icon(char *dst, uint8_t pct)
-{
-    LCD_WriteCmd(0x3A);      // Function set (RE=1)
-    LCD_WriteCmd(0x72);      // ROM selection
-    LCD_WriteCmd(0x00);      // ROM A
-    LCD_WriteCmd(0x38);      // Function set (RE=0)
-    dst[0] = '[';
-    for (int i = 0; i < 4; i++)
-        dst[i+1] = (pct >= (i+1)*25) ? 0x1F : ' ';
-    dst[5] = ']';
-    dst[6] = '\0';
-}
 
 /*---------------------------------------------------------------------------
  *  RUN screen rendering
@@ -135,8 +123,8 @@ static void ui_render_run(void)
     char l3[LCD_CHARS+1];
     memset(l3, ' ', LCD_CHARS);
     l3[LCD_CHARS] = '\0';
-    char batt_buf[7];
-    battery_icon(batt_buf, batt);
+    char batt_buf[5];
+    snprintf(batt_buf, sizeof(batt_buf), "%3u%%", batt);
     strcpy(l3 + LCD_CHARS - strlen(batt_buf), batt_buf);
 
     lcd_line(0,l0); lcd_line(1,l1); lcd_line(2,l2); lcd_line(3,l3);


### PR DESCRIPTION
## Summary
- Remove battery icon rendering from the UI
- Display numeric battery percentage on the bottom-right corner
- Drop unused `LCD_ShowBatteryPercentage` helper and related call

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68910239f94c8331a8603500550ed8c4